### PR TITLE
factor out fn.apply and add es2015 spread operators

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -1,21 +1,21 @@
-var slice = Array.prototype.slice;
-
-let _curry = (n, fn, curryArgs = []) => {
+let _curry = (fn, curryArgs = []) => {
   return (...args) => {
-    var concatArgs = curryArgs.concat(args);
+    var concatArgs = [...concatArgs, ...args];
 
-    if (n > concatArgs.length) {
-      return _curry(n, fn, concatArgs);
+    // If function arity greater than number of received args
+    if (fn.length > concatArgs.length) {
+      return _curry(fn, concatArgs);
     } else {
-      return fn.apply(null, slice.call(concatArgs, 0, n));
+      return fn(...concatArgs);
     }
   };
 };
 
 export function curry(fn) {
-  return _curry(fn.length, fn);
+  return _curry(fn);
 }
 
+// curryN now unnecessary
 export function curryN(n, fn) {
   return _curry(n, fn);
 }


### PR DESCRIPTION
This is a super cool idea.

It looks like these repos could use some TLC (e.g. updating to ES6, Babel, Node v6/7, etc). Would there be any interest in updating these repos, especially considering the renewed interest in functional programming in the JS community?